### PR TITLE
Fix multipass installation error

### DIFF
--- a/Casks/multipass.rb
+++ b/Casks/multipass.rb
@@ -1,3 +1,4 @@
+# typed: false
 cask "multipass" do
   version "1.5.0"
   sha256 "1085217279fbb55f3a2c528deaba7c19b60073ae715c39dc83273262fea1a117"
@@ -5,7 +6,7 @@ cask "multipass" do
   url "https://github.com/CanonicalLtd/multipass/releases/download/v#{version}/multipass-#{version}+mac-Darwin.pkg"
   appcast "https://github.com/CanonicalLtd/multipass/releases.atom"
   name "Multipass"
-  desc "Multipass orchestrates virtual Ubuntu instances"
+  desc "Orchestrates virtual Ubuntu instances"
   homepage "https://github.com/CanonicalLtd/multipass/"
 
   depends_on macos: ">= :sierra"

--- a/Casks/multipass.rb
+++ b/Casks/multipass.rb
@@ -5,6 +5,7 @@ cask "multipass" do
   url "https://github.com/CanonicalLtd/multipass/releases/download/v#{version}/multipass-#{version}+mac-Darwin.pkg"
   appcast "https://github.com/CanonicalLtd/multipass/releases.atom"
   name "Multipass"
+  desc "Multipass orchestrates virtual Ubuntu instances"
   homepage "https://github.com/CanonicalLtd/multipass/"
 
   depends_on macos: ">= :sierra"

--- a/Casks/multipass.rb
+++ b/Casks/multipass.rb
@@ -9,7 +9,7 @@ cask "multipass" do
 
   depends_on macos: ">= :sierra"
 
-  pkg "multipass-#{version} mac-Darwin.pkg"
+  pkg "multipass-#{version}+mac-Darwin.pkg"
 
   uninstall launchctl: "com.canonical.multipassd",
             pkgutil:   "com.canonical.multipass.*",


### PR DESCRIPTION
Fix installation error:
```
Error: Could not find PKG source file 'multipass-1.5.0 mac-Darwin.pkg', found 'multipass-1.5.0+mac-Darwin.pkg' instead.
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
